### PR TITLE
Add presentation id and load from host stage environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 ```
   <rise-embedded-template
     id="template"
-    template-id="5afded33-2739-4532-9e22-a2235a5bc8c2">
+    template-id="8d517e618b10991a995e53e334f707fc246de9cc"
+    presentation-id="25aa133d-d453-475b-a64a-efd165deef4b">
   </rise-embedded-template>
 ```
 
@@ -21,7 +22,8 @@ This attribute holds a literal value, for example:
   <rise-embedded-template
     id="template"
     label="Embedded Template"
-    template-id="5afded33-2739-4532-9e22-a2235a5bc8c2">
+    template-id="8d517e618b10991a995e53e334f707fc246de9cc"
+    presentation-id="25aa133d-d453-475b-a64a-efd165deef4b">
   </rise-embedded-template>
 ```
 
@@ -33,6 +35,7 @@ This component receives the following list of attributes:
 
 - **id**: ( string / required ): Unique HTMLElement id.
 - **template-id**: ( string / required ): HTML Template id.
+- **presentation-id**: ( string / no ): HTML Template instance presentation id. The template is loaded with the default values if this attribute is absent.
 - **label**: ( string / optional ): An optional label key for the text that will appear in the template editor. See 'Labels' section above.
 - **non-editable**: ( empty / optional ): If present, it indicates this component is not available for customization in the template editor.
 

--- a/src/rise-embedded-template.js
+++ b/src/rise-embedded-template.js
@@ -25,10 +25,13 @@ export default class RiseEmbeddedTemplate extends RiseElement {
       templateId: {
         type: String
       },
+      presentationId: {
+        type: String
+      },
       url: {
         type: String,
         readOnly: true,
-        computed: "_computeUrl(templateId)"
+        computed: "_computeUrl(templateId, presentationId)"
       }
     }
   }
@@ -39,13 +42,25 @@ export default class RiseEmbeddedTemplate extends RiseElement {
     this._setVersion( version );
   }
 
-  _computeUrl(templateId) {
+  _computeUrl(templateId, presentationId) {
 
     if (!templateId) {
       return "about:blank";
     }
 
-    return `https://widgets.risevision.com/stable/templates/${templateId}/src/template.html`;
+    const templateStage = this._getHostTemplatePath().startsWith("/staging") ? "staging" : "stable";
+
+    let url = `https://widgets.risevision.com/${templateStage}/templates/${templateId}/src/template.html`
+
+    if (presentationId) {
+      url = `${url}?presentationId=${presentationId}`;
+    }
+
+    return url;
+  }
+
+  _getHostTemplatePath() {
+    return window.location.pathname;
   }
 }
 

--- a/test/rise-embedded-template-test.html
+++ b/test/rise-embedded-template-test.html
@@ -53,6 +53,24 @@
           assert.equal(element.url, 'https://widgets.risevision.com/stable/templates/8d517e618b10991a995e53e334f707fc246de9cc/src/template.html');
         });
 
+        test('should set presentation id parameter in the template URL', () => {
+          const element = fixture('StaticValueTestFixture');
+
+          element.presentationId = "25aa133d-d453-475b-a64a-efd165deef4b";
+
+          assert.equal(element.url, 'https://widgets.risevision.com/stable/templates/8d517e618b10991a995e53e334f707fc246de9cc/src/template.html?presentationId=25aa133d-d453-475b-a64a-efd165deef4b');
+        });
+
+        test('should load template from staging if host template is also on staging', () => {
+          const element = fixture('StaticValueTestFixture');
+
+          sandbox.stub(element, "_getHostTemplatePath").returns("/staging/templates/6fb889c4dd821ad7092ff7b68e70cbdef9ccfa51/src/template.html");
+
+          element.presentationId = "25aa133d-d453-475b-a64a-efd165deef4b";
+
+          assert.equal(element.url, 'https://widgets.risevision.com/staging/templates/8d517e618b10991a995e53e334f707fc246de9cc/src/template.html?presentationId=25aa133d-d453-475b-a64a-efd165deef4b');
+        });
+
         test('should render iframe with template url', () => {
           const element = fixture('StaticValueTestFixture');
           const object = element.shadowRoot.children[0];


### PR DESCRIPTION
## Description
- Presentation id is needed because the template uses it to watch for the attribute data file and get the data the user has set for that particular template instance (presentation)
- Embedded template should be loaded from the same environment as the host template: if host template is loaded from staging, the embedded template is also loaded from staging and also the other way around with stable

## Motivation and Context
- We need presentation id so that the embedded template can fetch its data.
- We should load embedded templates according to the host template environment for consistency

## How Has This Been Tested?
Added unit tests and tested locally with Chrome OS Player and proxy.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
