### PR TITLE
Add PUD

### DIFF
--- a/src/rise-embedded-template.js
+++ b/src/rise-embedded-template.js
@@ -68,10 +68,22 @@ export default class RiseEmbeddedTemplate extends RiseElement {
 
     this.addEventListener("rise-playlist-play", () => this._sendMessageToTemplate({ topic: "rise-presentation-play" }));
     this.addEventListener("rise-playlist-stop", () => this._sendMessageToTemplate({ topic: "rise-presentation-stop" }));
+
+    window.addEventListener("message", event => this._handleMessageFromTemplate(event), false);
   }
 
   _sendMessageToTemplate(message) {
     this.$.template.contentWindow.postMessage(message, this.url);
+  }
+
+  _handleMessageFromTemplate(event) {
+    if (event.source !== this.$.template.contentWindow) {
+      return;
+    }
+
+    if (event.data.topic === "template-done") {
+      super._sendDoneEvent(true);
+    }
   }
 }
 

--- a/test/rise-embedded-template-test.html
+++ b/test/rise-embedded-template-test.html
@@ -141,6 +141,22 @@
           assert.equal(element._sendDoneEvent.called, false);
         });
 
+        test('should not send "report-done" event when message is not "template-done"', () => {
+          // stub super class method
+          sandbox.stub(RiseElement.prototype, "_sendDoneEvent");
+
+          const element = fixture('StaticValueTestFixture');
+          const iframe = element.shadowRoot.children[0];
+
+          const event = new Event("message");
+          event.data = { topic: "other-topic" };
+          event.source = iframe.contentWindow;
+
+          element._handleMessageFromTemplate(event);
+
+          assert.equal(element._sendDoneEvent.called, false);
+        });
+
       });
     </script>
 

--- a/test/rise-embedded-template-test.html
+++ b/test/rise-embedded-template-test.html
@@ -33,6 +33,8 @@
     </test-fixture>
 
     <script type="module">
+      import { RiseElement } from "rise-common-component/src/rise-element.js";
+
       suite('rise-embedded-template', () => {
         const sandbox = sinon.createSandbox();
 
@@ -107,19 +109,36 @@
           assert.equal(element._sendMessageToTemplate.calledWith({ topic: "rise-presentation-stop" }), true);
         });
 
-        test('should send "report-done" event when template is done', (done) => {
+        test('should send "report-done" event when template is done', () => {
+          // stub super class method
+          sandbox.stub(RiseElement.prototype, "_sendDoneEvent");
+
           const element = fixture('StaticValueTestFixture');
           const iframe = element.shadowRoot.children[0];
-
-          element.addEventListener("report-done", () => {
-            done();
-          });
 
           const event = new Event("message");
           event.data = { topic: "template-done" };
           event.source = iframe.contentWindow;
 
           element._handleMessageFromTemplate(event);
+
+          assert.equal(element._sendDoneEvent.called, true);
+        });
+
+        test('should not send "report-done" event when "template-done" message is from a different source', () => {
+          // stub super class method
+          sandbox.stub(RiseElement.prototype, "_sendDoneEvent");
+
+          const element = fixture('StaticValueTestFixture');
+          const iframe = element.shadowRoot.children[0];
+
+          const event = new Event("message");
+          event.data = { topic: "template-done" };
+          event.source = {};
+
+          element._handleMessageFromTemplate(event);
+
+          assert.equal(element._sendDoneEvent.called, false);
         });
 
       });

--- a/test/rise-embedded-template-test.html
+++ b/test/rise-embedded-template-test.html
@@ -107,6 +107,21 @@
           assert.equal(element._sendMessageToTemplate.calledWith({ topic: "rise-presentation-stop" }), true);
         });
 
+        test('should send "report-done" event when template is done', (done) => {
+          const element = fixture('StaticValueTestFixture');
+          const iframe = element.shadowRoot.children[0];
+
+          element.addEventListener("report-done", () => {
+            done();
+          });
+
+          const event = new Event("message");
+          event.data = { topic: "template-done" };
+          event.source = iframe.contentWindow;
+
+          element._handleMessageFromTemplate(event);
+        });
+
       });
     </script>
 


### PR DESCRIPTION
## Description
- Send done event when embedded template is done

## Motivation and Context
PUD works in `rise-playlist` when `rise-playlist-item` is marked with "play-until-done" and has a `rise-embedded-template` child. See: https://github.com/Rise-Vision/rise-playlist-new/pull/8

## How Has This Been Tested?
Tested locally on Chrome Player

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
