### PR TITLE
Put a limit on level of embedding in order to prevent circular references

### DIFF
--- a/src/rise-embedded-template.js
+++ b/src/rise-embedded-template.js
@@ -31,13 +31,12 @@ export default class RiseEmbeddedTemplate extends RiseElement {
         type: String,
         readOnly: true,
         computed: "_computeUrl(templateId, presentationId)"
-      },
-      _MAX_EMBED_LEVEL: {
-        type: Number,
-        readOnly: true,
-        value: 5
       }
     }
+  }
+
+  static get MAX_EMBED_LEVEL() {
+    return 5;
   }
 
   constructor() {
@@ -54,7 +53,7 @@ export default class RiseEmbeddedTemplate extends RiseElement {
       return "about:blank";
     }
 
-    if (this._currentLevelOfEmbedding >= this._MAX_EMBED_LEVEL) {
+    if (this._currentLevelOfEmbedding >= RiseEmbeddedTemplate.MAX_EMBED_LEVEL) {
       return "data:text/html;charset=utf-8,<html><body>Maximum level of embedding is reached</body></html>";
     }
 
@@ -83,7 +82,7 @@ export default class RiseEmbeddedTemplate extends RiseElement {
     currentLevel = currentLevel || 0;
     currentWindow = currentWindow || window.self;
 
-    if (window.top != currentWindow && currentWindow.parent && currentLevel < this._MAX_EMBED_LEVEL) {
+    if (window.top != currentWindow && currentWindow.parent && currentLevel < RiseEmbeddedTemplate.MAX_EMBED_LEVEL) {
       return this._getLevelOfEmbedding(currentWindow.parent, currentLevel + 1);
     } else {
       return currentLevel;

--- a/test/rise-embedded-template-test.html
+++ b/test/rise-embedded-template-test.html
@@ -21,7 +21,6 @@
       };
     </script>
 
-    <script type="module" src="../src/rise-embedded-template.js"></script>
   </head>
   <body>
 
@@ -32,15 +31,9 @@
       </template>
     </test-fixture>
 
-    <test-fixture id="MaxLevelFixture">
-      <template>
-        <rise-embedded-template template-id="8d517e618b10991a995e53e334f707fc246de9cc" _MAX_EMBED_LEVEL=1>
-        </rise-embedded-template>
-      </template>
-    </test-fixture>
-
     <script type="module">
       import { RiseElement } from "rise-common-component/src/rise-element.js";
+      import RiseEmbeddedTemplate from "../src/rise-embedded-template.js";
 
       suite('rise-embedded-template', () => {
         const sandbox = sinon.createSandbox();
@@ -249,7 +242,7 @@
 
           let level = element._getLevelOfEmbedding(sampleWindowFixture);
 
-          assert.equal(level, element._MAX_EMBED_LEVEL);
+          assert.equal(level, RiseEmbeddedTemplate.MAX_EMBED_LEVEL);
         });
 
         test('should set _currentLevelOfEmbedding in constructor', () => {
@@ -260,10 +253,8 @@
         });
 
         test('should show static message wen maximum level of embedding is reached', () => {
-          const element = fixture('MaxLevelFixture');
-
-          element._currentLevelOfEmbedding = element._MAX_EMBED_LEVEL;
-          element.templateId = '123'; //trigger re-calculation of URL
+          sinon.stub(RiseEmbeddedTemplate, 'MAX_EMBED_LEVEL').get(() => 1);
+          const element = fixture('StaticValueTestFixture');
 
           assert.equal(element.url, 'data:text/html;charset=utf-8,<html><body>Maximum level of embedding is reached</body></html>');
         });

--- a/test/rise-embedded-template-test.html
+++ b/test/rise-embedded-template-test.html
@@ -32,6 +32,13 @@
       </template>
     </test-fixture>
 
+    <test-fixture id="MaxLevelFixture">
+      <template>
+        <rise-embedded-template template-id="8d517e618b10991a995e53e334f707fc246de9cc" _MAX_EMBED_LEVEL=1>
+        </rise-embedded-template>
+      </template>
+    </test-fixture>
+
     <script type="module">
       import { RiseElement } from "rise-common-component/src/rise-element.js";
 
@@ -214,6 +221,51 @@
           element._handleMessageFromTemplate(event);
 
           assert.equal(element._sendEvent.calledWith("rise-components-ready"), true);
+        });
+
+        test('should calculate level of embedding correctly', () => {
+          const element = fixture('StaticValueTestFixture');
+
+          let topWindow = {};
+          let sampleWindowFixture = {  //level 2
+            top: topWindow,
+            parent: { //level 1
+              parent: topWindow //level 0
+            } 
+          };
+
+          let level = element._getLevelOfEmbedding(sampleWindowFixture);
+
+          assert.equal(level, 2);
+        });
+
+        test('should not exceed maximum level of embedding', () => {
+          const element = fixture('StaticValueTestFixture');
+
+          let topWindow = {};
+          let sampleWindowFixture = {};
+          //create circular reference so simulate indefine nesting
+          sampleWindowFixture.parent = sampleWindowFixture;
+
+          let level = element._getLevelOfEmbedding(sampleWindowFixture);
+
+          assert.equal(level, element._MAX_EMBED_LEVEL);
+        });
+
+        test('should set _currentLevelOfEmbedding in constructor', () => {
+          const element = fixture('StaticValueTestFixture');
+
+          assert.exists(element._currentLevelOfEmbedding);
+          assert.isAbove(element._currentLevelOfEmbedding, 0);
+        });
+
+        test('should show static message wen maximum level of embedding is reached', () => {
+          const element = fixture('MaxLevelFixture');
+
+          element._currentLevelOfEmbedding = element._MAX_EMBED_LEVEL;
+          element.templateId = '123'; //trigger re-calculation of URL
+
+          assert.equal(element.url, 'data:text/html;charset=utf-8,<html><body>Maximum level of embedding is reached</body></html>');
         });
 
       });


### PR DESCRIPTION
## Description
Allow up to 5 levels of embedding. This gives enough room for a user to create presentation that references another presentation that in turn references another presentation and so on, but at the same time protects display from crashing if circular references is created.

## Motivation and Context
Protects display from crashing if circular references is created.

## How Has This Been Tested?
Added unit tests. Also tested manually by creating a presentation A that references presentation B which in turn references presentation A again. This was tested locally on Chrome Player. I confirmed that presentation A -> B -> A -> B -> A and then rendering stopped. Note, the "Maximum level of embedding is reached" message was hidden because playlist did not receive `rise-components-ready` message from the component. I decided to leave it as i.e. keep the "Maximum level of embedding is reached" message and keep it hidden because 1) there is no specific requirement of what should happen in this case 2) having this message in HTML can help us with troubleshooting.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
