### PR TITLE
Build the component to inject the package version for logging purposes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
       - restore_cache:
           key: node-cache-{{ checksum "package.json" }}
       - run: |
-          VERSION=$(cat version-string/version)
+          VERSION=$(grep version package.json | grep -o '[0-9.]*')
           sed -i "
             s/__VERSION__/$VERSION/;
           " src/rise-embedded-template-version.js


### PR DESCRIPTION
## Description
Update the _build_ CCI job to obtain the version value from _package.json_ for injecting into component source code.

## Motivation and Context
When components log to BQ, they log their _version_ and the value should be their _package.json_ value, not the _timestamp_ version value created by the CCI build for use in staging deployment process. All components should be consistent in this value. 

## How Has This Been Tested?
CCI - https://circleci.com/workflow-run/1a2ea8fe-302d-4f38-b2af-b4502df8b78f

Deployed source code with version value - https://www.screencast.com/t/Dyn3Bn1K

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
