### PR TITLE
Add parameters to Template URL; forward messages to iframes

### DIFF
--- a/src/rise-embedded-template.js
+++ b/src/rise-embedded-template.js
@@ -121,7 +121,7 @@ export default class RiseEmbeddedTemplate extends RiseElement {
       this._handleMessageFromTemplate(event);
     } else if (this.$.template.contentWindow && event.data && 
       (event.data.type === "attributeData" || event.data.type === "displayData")) {
-      this.$.template.contentWindow.postMessage( event.data, this.url);  
+      this._sendMessageToTemplate( event.data );
     }
   }
 

--- a/src/rise-embedded-template.js
+++ b/src/rise-embedded-template.js
@@ -60,7 +60,7 @@ export default class RiseEmbeddedTemplate extends RiseElement {
     const templateStage = this._getHostTemplatePath().startsWith("/staging") ? "staging" : "stable";
 
     const protocol = this._getHostTemplateProtocol();
-    const type = this._getHttpParameter("type");
+    const type = RisePlayerConfiguration.Helpers.getHttpParameter("type");
 
     let url = `${protocol}//widgets.risevision.com/${templateStage}/templates/${templateId}/src/template.html`
 
@@ -77,20 +77,6 @@ export default class RiseEmbeddedTemplate extends RiseElement {
 
   _getHostTemplatePath() {
     return window.location.pathname;
-  }
-
-  _getHttpParameter( name ) {
-    try {
-      const href = window.location.href;
-      const regex = new RegExp( `[?&]${ name }=([^&#]*)`, "i" );
-      const match = regex.exec( href );
-
-      return match ? match[ 1 ] : null;
-    } catch ( err ) {
-      console.log( "can't retrieve HTTP parameter", err );
-
-      return null;
-    }
   }
 
   _getLevelOfEmbedding(currentWindow, currentLevel) {

--- a/src/rise-embedded-template.js
+++ b/src/rise-embedded-template.js
@@ -112,7 +112,7 @@ export default class RiseEmbeddedTemplate extends RiseElement {
   }
 
   _sendMessageToTemplate(message) {
-    console.log(`${this.id} sending ${message.topic} to template`);
+    console.log(`${this.id} sending ${message.topic || message.type} to template`);
     this.$.template.contentWindow.postMessage(message, this.url);
   }
 
@@ -120,7 +120,7 @@ export default class RiseEmbeddedTemplate extends RiseElement {
     if (event.source === this.$.template.contentWindow) {
       this._handleMessageFromTemplate(event);
     } else if (this.$.template.contentWindow && event.data && 
-      (event.data.type === "attributeData" || event.data.type === "displayData")) {
+      (event.data.type === "attributeData" || event.data.type === "displayData" || event.data.type === "sendStartEvent")) {
       this._sendMessageToTemplate( event.data );
     }
   }

--- a/src/rise-embedded-template.js
+++ b/src/rise-embedded-template.js
@@ -65,7 +65,7 @@ export default class RiseEmbeddedTemplate extends RiseElement {
     let url = `${protocol}//widgets.risevision.com/${templateStage}/templates/${templateId}/src/template.html`
 
     if (presentationId) {
-      url = `${url}?presentationId=${presentationId}&type=${type}`;
+      url = `${url}?presentationId=${presentationId}&type=${type}&frameElementId=template_${presentationId}`;
     }
 
     return url;

--- a/src/rise-embedded-template.js
+++ b/src/rise-embedded-template.js
@@ -60,11 +60,12 @@ export default class RiseEmbeddedTemplate extends RiseElement {
     const templateStage = this._getHostTemplatePath().startsWith("/staging") ? "staging" : "stable";
 
     const protocol = this._getHostTemplateProtocol();
+    const type = this._getHttpParameter("type");
 
     let url = `${protocol}//widgets.risevision.com/${templateStage}/templates/${templateId}/src/template.html`
 
     if (presentationId) {
-      url = `${url}?presentationId=${presentationId}`;
+      url = `${url}?presentationId=${presentationId}&type=${type}`;
     }
 
     return url;
@@ -76,6 +77,20 @@ export default class RiseEmbeddedTemplate extends RiseElement {
 
   _getHostTemplatePath() {
     return window.location.pathname;
+  }
+
+  _getHttpParameter( name ) {
+    try {
+      const href = window.location.href;
+      const regex = new RegExp( `[?&]${ name }=([^&#]*)`, "i" );
+      const match = regex.exec( href );
+
+      return match ? match[ 1 ] : null;
+    } catch ( err ) {
+      console.log( "can't retrieve HTTP parameter", err );
+
+      return null;
+    }
   }
 
   _getLevelOfEmbedding(currentWindow, currentLevel) {

--- a/test/rise-embedded-template-test.html
+++ b/test/rise-embedded-template-test.html
@@ -60,7 +60,7 @@
 
           element.presentationId = "25aa133d-d453-475b-a64a-efd165deef4b";
 
-          assert.equal(element.url, 'http://widgets.risevision.com/stable/templates/8d517e618b10991a995e53e334f707fc246de9cc/src/template.html?presentationId=25aa133d-d453-475b-a64a-efd165deef4b&type=null');
+          assert.equal(element.url, 'http://widgets.risevision.com/stable/templates/8d517e618b10991a995e53e334f707fc246de9cc/src/template.html?presentationId=25aa133d-d453-475b-a64a-efd165deef4b&type=null&frameElementId=template_25aa133d-d453-475b-a64a-efd165deef4b');
         });
 
         test('should load template from staging if host template is also on staging', () => {
@@ -70,7 +70,7 @@
 
           element.presentationId = "25aa133d-d453-475b-a64a-efd165deef4b";
 
-          assert.equal(element.url, 'http://widgets.risevision.com/staging/templates/8d517e618b10991a995e53e334f707fc246de9cc/src/template.html?presentationId=25aa133d-d453-475b-a64a-efd165deef4b&type=null');
+          assert.equal(element.url, 'http://widgets.risevision.com/staging/templates/8d517e618b10991a995e53e334f707fc246de9cc/src/template.html?presentationId=25aa133d-d453-475b-a64a-efd165deef4b&type=null&frameElementId=template_25aa133d-d453-475b-a64a-efd165deef4b');
         });
 
         test('should load template from https if host template is also on https', () => {
@@ -81,7 +81,7 @@
 
           element.presentationId = "25aa133d-d453-475b-a64a-efd165deef4b";
 
-          assert.equal(element.url, 'https://widgets.risevision.com/staging/templates/8d517e618b10991a995e53e334f707fc246de9cc/src/template.html?presentationId=25aa133d-d453-475b-a64a-efd165deef4b&type=null');
+          assert.equal(element.url, 'https://widgets.risevision.com/staging/templates/8d517e618b10991a995e53e334f707fc246de9cc/src/template.html?presentationId=25aa133d-d453-475b-a64a-efd165deef4b&type=null&frameElementId=template_25aa133d-d453-475b-a64a-efd165deef4b');
         });
 
         test('should render iframe with template url', () => {

--- a/test/rise-embedded-template-test.html
+++ b/test/rise-embedded-template-test.html
@@ -60,7 +60,7 @@
 
           element.presentationId = "25aa133d-d453-475b-a64a-efd165deef4b";
 
-          assert.equal(element.url, 'http://widgets.risevision.com/stable/templates/8d517e618b10991a995e53e334f707fc246de9cc/src/template.html?presentationId=25aa133d-d453-475b-a64a-efd165deef4b');
+          assert.equal(element.url, 'http://widgets.risevision.com/stable/templates/8d517e618b10991a995e53e334f707fc246de9cc/src/template.html?presentationId=25aa133d-d453-475b-a64a-efd165deef4b&type=null');
         });
 
         test('should load template from staging if host template is also on staging', () => {
@@ -70,7 +70,7 @@
 
           element.presentationId = "25aa133d-d453-475b-a64a-efd165deef4b";
 
-          assert.equal(element.url, 'http://widgets.risevision.com/staging/templates/8d517e618b10991a995e53e334f707fc246de9cc/src/template.html?presentationId=25aa133d-d453-475b-a64a-efd165deef4b');
+          assert.equal(element.url, 'http://widgets.risevision.com/staging/templates/8d517e618b10991a995e53e334f707fc246de9cc/src/template.html?presentationId=25aa133d-d453-475b-a64a-efd165deef4b&type=null');
         });
 
         test('should load template from https if host template is also on https', () => {
@@ -81,7 +81,7 @@
 
           element.presentationId = "25aa133d-d453-475b-a64a-efd165deef4b";
 
-          assert.equal(element.url, 'https://widgets.risevision.com/staging/templates/8d517e618b10991a995e53e334f707fc246de9cc/src/template.html?presentationId=25aa133d-d453-475b-a64a-efd165deef4b');
+          assert.equal(element.url, 'https://widgets.risevision.com/staging/templates/8d517e618b10991a995e53e334f707fc246de9cc/src/template.html?presentationId=25aa133d-d453-475b-a64a-efd165deef4b&type=null');
         });
 
         test('should render iframe with template url', () => {

--- a/test/rise-embedded-template-test.html
+++ b/test/rise-embedded-template-test.html
@@ -264,6 +264,21 @@
           assert.equal(iframe.contentWindow.postMessage.calledWith(event.data, "http://widgets.risevision.com/stable/templates/8d517e618b10991a995e53e334f707fc246de9cc/src/template.html"), true);
         });
 
+        test('should forward sendStartEvent messages to iframe', () => {
+          const element = fixture('StaticValueTestFixture');
+          const iframe = element.shadowRoot.children[0];
+
+          const event = new Event("message");
+          event.data = { type: "sendStartEvent" };
+          event.source = {};
+
+          sandbox.stub(iframe.contentWindow, "postMessage");
+
+          element._handleMessage(event);
+
+          assert.equal(iframe.contentWindow.postMessage.calledWith(event.data, "http://widgets.risevision.com/stable/templates/8d517e618b10991a995e53e334f707fc246de9cc/src/template.html"), true);
+        });
+
         test('should not forward other messages to iframe', () => {
           const element = fixture('StaticValueTestFixture');
           const iframe = element.shadowRoot.children[0];

--- a/test/rise-embedded-template-test.html
+++ b/test/rise-embedded-template-test.html
@@ -17,7 +17,10 @@
       RisePlayerConfiguration = {
         isConfigured: () => true,
         isPreview: sinon.stub().returns(true),
-        Logger: {}
+        Logger: {},
+        Helpers: {
+          getHttpParameter: sinon.stub().returns("type")
+        }
       };
     </script>
 
@@ -60,7 +63,7 @@
 
           element.presentationId = "25aa133d-d453-475b-a64a-efd165deef4b";
 
-          assert.equal(element.url, 'http://widgets.risevision.com/stable/templates/8d517e618b10991a995e53e334f707fc246de9cc/src/template.html?presentationId=25aa133d-d453-475b-a64a-efd165deef4b&type=null&frameElementId=template_25aa133d-d453-475b-a64a-efd165deef4b');
+          assert.equal(element.url, 'http://widgets.risevision.com/stable/templates/8d517e618b10991a995e53e334f707fc246de9cc/src/template.html?presentationId=25aa133d-d453-475b-a64a-efd165deef4b&type=type&frameElementId=template_25aa133d-d453-475b-a64a-efd165deef4b');
         });
 
         test('should load template from staging if host template is also on staging', () => {
@@ -70,7 +73,7 @@
 
           element.presentationId = "25aa133d-d453-475b-a64a-efd165deef4b";
 
-          assert.equal(element.url, 'http://widgets.risevision.com/staging/templates/8d517e618b10991a995e53e334f707fc246de9cc/src/template.html?presentationId=25aa133d-d453-475b-a64a-efd165deef4b&type=null&frameElementId=template_25aa133d-d453-475b-a64a-efd165deef4b');
+          assert.equal(element.url, 'http://widgets.risevision.com/staging/templates/8d517e618b10991a995e53e334f707fc246de9cc/src/template.html?presentationId=25aa133d-d453-475b-a64a-efd165deef4b&type=type&frameElementId=template_25aa133d-d453-475b-a64a-efd165deef4b');
         });
 
         test('should load template from https if host template is also on https', () => {
@@ -81,7 +84,7 @@
 
           element.presentationId = "25aa133d-d453-475b-a64a-efd165deef4b";
 
-          assert.equal(element.url, 'https://widgets.risevision.com/staging/templates/8d517e618b10991a995e53e334f707fc246de9cc/src/template.html?presentationId=25aa133d-d453-475b-a64a-efd165deef4b&type=null&frameElementId=template_25aa133d-d453-475b-a64a-efd165deef4b');
+          assert.equal(element.url, 'https://widgets.risevision.com/staging/templates/8d517e618b10991a995e53e334f707fc246de9cc/src/template.html?presentationId=25aa133d-d453-475b-a64a-efd165deef4b&type=type&frameElementId=template_25aa133d-d453-475b-a64a-efd165deef4b');
         });
 
         test('should render iframe with template url', () => {
@@ -168,22 +171,6 @@
           assert.equal(element._sendDoneEvent.called, true);
         });
 
-        test('should not send "report-done" event when "template-done" message is from a different source', () => {
-          // stub super class method
-          sandbox.stub(RiseElement.prototype, "_sendDoneEvent");
-
-          const element = fixture('StaticValueTestFixture');
-          const iframe = element.shadowRoot.children[0];
-
-          const event = new Event("message");
-          event.data = { topic: "template-done" };
-          event.source = {};
-
-          element._handleMessage(event);
-
-          assert.equal(element._sendDoneEvent.called, false);
-        });
-
         test('should not send "report-done" event when message is not "template-done"', () => {
           // stub super class method
           sandbox.stub(RiseElement.prototype, "_sendDoneEvent");
@@ -214,6 +201,82 @@
           element._handleMessage(event);
 
           assert.equal(element._sendEvent.calledWith("rise-components-ready"), true);
+        });
+
+        test('should send "rise-components-error" event when template sends it', () => {
+          // stub super class method
+          sandbox.stub(RiseElement.prototype, "_sendEvent");
+
+          const element = fixture('StaticValueTestFixture');
+          const iframe = element.shadowRoot.children[0];
+
+          const event = new Event("message");
+          event.data = { topic: "template-error" };
+          event.source = iframe.contentWindow;
+
+          element._handleMessage(event);
+
+          assert.equal(element._sendEvent.calledWith("rise-components-error"), true);
+        });
+
+        test('should not send when message is from a different source', () => {
+          const element = fixture('StaticValueTestFixture');
+          const iframe = element.shadowRoot.children[0];
+
+          const event = new Event("message");
+          event.data = { topic: "template-done" };
+          event.source = {};
+
+          sandbox.stub(element, "_sendMessageToTemplate");
+
+          element._handleMessage(event);
+
+          assert.equal(element._sendMessageToTemplate.called, false);
+        });
+
+        test('should forward attributeData messages to iframe', () => {
+          const element = fixture('StaticValueTestFixture');
+          const iframe = element.shadowRoot.children[0];
+
+          const event = new Event("message");
+          event.data = { type: "attributeData" };
+          event.source = {};
+
+          sandbox.stub(iframe.contentWindow, "postMessage");
+
+          element._handleMessage(event);
+
+          assert.equal(iframe.contentWindow.postMessage.calledWith(event.data, "http://widgets.risevision.com/stable/templates/8d517e618b10991a995e53e334f707fc246de9cc/src/template.html"), true);
+        });
+
+        test('should forward displayData messages to iframe', () => {
+          const element = fixture('StaticValueTestFixture');
+          const iframe = element.shadowRoot.children[0];
+
+          const event = new Event("message");
+          event.data = { type: "displayData" };
+          event.source = {};
+
+          sandbox.stub(iframe.contentWindow, "postMessage");
+
+          element._handleMessage(event);
+
+          assert.equal(iframe.contentWindow.postMessage.calledWith(event.data, "http://widgets.risevision.com/stable/templates/8d517e618b10991a995e53e334f707fc246de9cc/src/template.html"), true);
+        });
+
+        test('should not forward other messages to iframe', () => {
+          const element = fixture('StaticValueTestFixture');
+          const iframe = element.shadowRoot.children[0];
+
+          const event = new Event("message");
+          event.data = { type: "randomMessage" };
+          event.source = {};
+
+          sandbox.stub(iframe.contentWindow, "postMessage");
+
+          element._handleMessage(event);
+
+          assert.equal(iframe.contentWindow.postMessage.called, false);
         });
 
         test('should calculate level of embedding correctly', () => {

--- a/test/rise-embedded-template-test.html
+++ b/test/rise-embedded-template-test.html
@@ -107,7 +107,7 @@
           const event = new Event("message");
           event.data = { topic: "rise-components-ready" };
           event.source = iframe.contentWindow;
-          element._handleMessageFromTemplate(event);
+          element._handleMessage(event);
 
           sandbox.stub(element, "_sendMessageToTemplate");
 
@@ -123,7 +123,7 @@
           const event = new Event("message");
           event.data = { topic: "rise-components-ready" };
           event.source = iframe.contentWindow;
-          element._handleMessageFromTemplate(event);
+          element._handleMessage(event);
 
           sandbox.stub(element, "_sendMessageToTemplate");
 
@@ -163,7 +163,7 @@
           event.data = { topic: "template-done" };
           event.source = iframe.contentWindow;
 
-          element._handleMessageFromTemplate(event);
+          element._handleMessage(event);
 
           assert.equal(element._sendDoneEvent.called, true);
         });
@@ -179,7 +179,7 @@
           event.data = { topic: "template-done" };
           event.source = {};
 
-          element._handleMessageFromTemplate(event);
+          element._handleMessage(event);
 
           assert.equal(element._sendDoneEvent.called, false);
         });
@@ -195,7 +195,7 @@
           event.data = { topic: "other-topic" };
           event.source = iframe.contentWindow;
 
-          element._handleMessageFromTemplate(event);
+          element._handleMessage(event);
 
           assert.equal(element._sendDoneEvent.called, false);
         });
@@ -211,7 +211,7 @@
           event.data = { topic: "rise-components-ready" };
           event.source = iframe.contentWindow;
 
-          element._handleMessageFromTemplate(event);
+          element._handleMessage(event);
 
           assert.equal(element._sendEvent.calledWith("rise-components-ready"), true);
         });


### PR DESCRIPTION
## Description
Add type and frameElementId parameters to Template URL

Forward messages with displayData and attributeData to iframes

## Motivation and Context
Parameters are consistent with the ones required for Viewer to render HTML Templates. Should not affect behaviour on Displays.

Will allow Embedded Templates to be rendered in Preview & Sharedschedules.

## How Has This Been Tested?
Tested locally that Embedded Templates render as expected. Updated unit tests. Will run various scenarios to test the changes.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No