### PR TITLE
Support standard rise-presentation-play/stop events

### DIFF
--- a/src/rise-embedded-template.js
+++ b/src/rise-embedded-template.js
@@ -93,8 +93,8 @@ export default class RiseEmbeddedTemplate extends RiseElement {
   ready() {
     super.ready();
 
-    this.addEventListener("rise-playlist-play", () => this._play());
-    this.addEventListener("rise-playlist-stop", () => this._stop());
+    this.addEventListener("rise-playlist-play", () => this._handleRisePresentationPlay());
+    this.addEventListener("rise-playlist-stop", () => this._handleRisePresentationStop());
 
     window.addEventListener("message", event => this._handleMessage(event), false);
   }
@@ -103,13 +103,17 @@ export default class RiseEmbeddedTemplate extends RiseElement {
     super._handleStart( event, true );
   }
 
-  _play() {
+  _handleRisePresentationPlay() {
+    super._handleRisePresentationPlay();
+
     if (this._templateIsReady) {
       this._sendMessageToTemplate({ topic: "rise-presentation-play" })
     }
   }
 
-  _stop() {
+  _handleRisePresentationStop() {
+    super._handleRisePresentationStop();
+
     if (this._templateIsReady) {
       this._sendMessageToTemplate({ topic: "rise-presentation-stop" })
     }

--- a/test/rise-embedded-template-test.html
+++ b/test/rise-embedded-template-test.html
@@ -103,56 +103,127 @@
           assert.equal(object.src, "about:blank");
         });
 
-        test('should send "rise-presentation-play" to template on "rise-playlist-play" event', () => {
-          const element = fixture('StaticValueTestFixture');
-          const iframe = element.shadowRoot.children[0];
+        suite( "play/stop events", () => {
+          let element;
 
-          const event = new Event("message");
-          event.data = { topic: "rise-components-ready" };
-          event.source = iframe.contentWindow;
-          element._handleMessage(event);
+          setup(()=>{
+            element = fixture('StaticValueTestFixture');
 
-          sandbox.stub(element, "_sendMessageToTemplate");
+            sandbox.spy(RiseElement.prototype, "_handleRisePresentationPlay");
+            sandbox.spy(RiseElement.prototype, "_handleRisePresentationStop");
+          });
 
-          element.dispatchEvent(new Event("rise-playlist-play"));
+          test('should call _handleRisePresentationPlay super function', () => {
+            element._handleRisePresentationPlay();
+            
+            assert.equal(RiseElement.prototype._handleRisePresentationPlay.called, true);
+          });
 
-          assert.equal(element._sendMessageToTemplate.calledWith({ topic: "rise-presentation-play" }), true);
+          test('should call _handleRisePresentationStop super function', () => {
+            element._handleRisePresentationStop();
+            
+            assert.equal(RiseElement.prototype._handleRisePresentationStop.called, true);
+          });
+
+          test('should send "rise-presentation-play" to template on "rise-presentation-play" event', () => {
+            const iframe = element.shadowRoot.children[0];
+
+            const event = new Event("message");
+            event.data = { topic: "rise-components-ready" };
+            event.source = iframe.contentWindow;
+            element._handleMessage(event);
+
+            sandbox.stub(element, "_sendMessageToTemplate");
+
+            element.dispatchEvent(new Event("rise-presentation-play"));
+
+            assert.equal(element._sendMessageToTemplate.calledWith({ topic: "rise-presentation-play" }), true);
+          });
+
+          test('should send "rise-presentation-stop" to template on "rise-presentation-stop" event', () => {
+            const iframe = element.shadowRoot.children[0];
+
+            const event = new Event("message");
+            event.data = { topic: "rise-components-ready" };
+            event.source = iframe.contentWindow;
+            element._handleMessage(event);
+
+            sandbox.stub(element, "_sendMessageToTemplate");
+
+            element.dispatchEvent(new Event("rise-presentation-stop"));
+
+            assert.equal(element._sendMessageToTemplate.calledWith({ topic: "rise-presentation-stop" }), true);
+          });
+
+          test('should not "rise-presentation-play" to template on "rise-presentation-play" event if template is not ready', () => {
+            sandbox.stub(element, "_sendMessageToTemplate");
+
+            element.dispatchEvent(new Event("rise-presentation-play"));
+
+            assert.equal(element._sendMessageToTemplate.calledWith({ topic: "rise-presentation-play" }), false);
+          });
+
+          test('should not "rise-presentation-stop" to template on "rise-presentation-stop" event if template is not ready', () => {
+            sandbox.stub(element, "_sendMessageToTemplate");
+
+            element.dispatchEvent(new Event("rise-presentation-stop"));
+
+            assert.equal(element._sendMessageToTemplate.calledWith({ topic: "rise-presentation-stop" }), false);
+          });
         });
 
-        test('should send "rise-presentation-stop" to template on "rise-playlist-stop" event', () => {
-          const element = fixture('StaticValueTestFixture');
-          const iframe = element.shadowRoot.children[0];
+        suite( "legacy play/stop events", () => {
+          test('should send "rise-presentation-play" to template on "rise-playlist-play" event', () => {
+            const element = fixture('StaticValueTestFixture');
+            const iframe = element.shadowRoot.children[0];
 
-          const event = new Event("message");
-          event.data = { topic: "rise-components-ready" };
-          event.source = iframe.contentWindow;
-          element._handleMessage(event);
+            const event = new Event("message");
+            event.data = { topic: "rise-components-ready" };
+            event.source = iframe.contentWindow;
+            element._handleMessage(event);
 
-          sandbox.stub(element, "_sendMessageToTemplate");
+            sandbox.stub(element, "_sendMessageToTemplate");
 
-          element.dispatchEvent(new Event("rise-playlist-stop"));
+            element.dispatchEvent(new Event("rise-playlist-play"));
 
-          assert.equal(element._sendMessageToTemplate.calledWith({ topic: "rise-presentation-stop" }), true);
-        });
+            assert.equal(element._sendMessageToTemplate.calledWith({ topic: "rise-presentation-play" }), true);
+          });
 
-        test('should not "rise-presentation-play" to template on "rise-playlist-play" event if template is not ready', () => {
-          const element = fixture('StaticValueTestFixture');
+          test('should send "rise-presentation-stop" to template on "rise-playlist-stop" event', () => {
+            const element = fixture('StaticValueTestFixture');
+            const iframe = element.shadowRoot.children[0];
 
-          sandbox.stub(element, "_sendMessageToTemplate");
+            const event = new Event("message");
+            event.data = { topic: "rise-components-ready" };
+            event.source = iframe.contentWindow;
+            element._handleMessage(event);
 
-          element.dispatchEvent(new Event("rise-playlist-play"));
+            sandbox.stub(element, "_sendMessageToTemplate");
 
-          assert.equal(element._sendMessageToTemplate.calledWith({ topic: "rise-presentation-play" }), false);
-        });
+            element.dispatchEvent(new Event("rise-playlist-stop"));
 
-        test('should not "rise-presentation-stop" to template on "rise-playlist-stop" event if template is not ready', () => {
-          const element = fixture('StaticValueTestFixture');
+            assert.equal(element._sendMessageToTemplate.calledWith({ topic: "rise-presentation-stop" }), true);
+          });
 
-          sandbox.stub(element, "_sendMessageToTemplate");
+          test('should not "rise-presentation-play" to template on "rise-playlist-play" event if template is not ready', () => {
+            const element = fixture('StaticValueTestFixture');
 
-          element.dispatchEvent(new Event("rise-playlist-stop"));
+            sandbox.stub(element, "_sendMessageToTemplate");
 
-          assert.equal(element._sendMessageToTemplate.calledWith({ topic: "rise-presentation-stop" }), false);
+            element.dispatchEvent(new Event("rise-playlist-play"));
+
+            assert.equal(element._sendMessageToTemplate.calledWith({ topic: "rise-presentation-play" }), false);
+          });
+
+          test('should not "rise-presentation-stop" to template on "rise-playlist-stop" event if template is not ready', () => {
+            const element = fixture('StaticValueTestFixture');
+
+            sandbox.stub(element, "_sendMessageToTemplate");
+
+            element.dispatchEvent(new Event("rise-playlist-stop"));
+
+            assert.equal(element._sendMessageToTemplate.calledWith({ topic: "rise-presentation-stop" }), false);
+          });
         });
 
         test('should send "report-done" event when template is done', () => {


### PR DESCRIPTION
## Description
Support standard rise-presentation-play/stop events

Update play/stop function names for consistency
Override RiseElement functions and call super

## Motivation and Context
Playlist Component epic.

## How Has This Been Tested?
Tested changes locally with the proxy. Updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No