### PR TITLE
Remove deprecated event handlers

### DIFF
--- a/src/rise-embedded-template.js
+++ b/src/rise-embedded-template.js
@@ -93,9 +93,6 @@ export default class RiseEmbeddedTemplate extends RiseElement {
   ready() {
     super.ready();
 
-    this.addEventListener("rise-playlist-play", () => this._handleRisePresentationPlay());
-    this.addEventListener("rise-playlist-stop", () => this._handleRisePresentationStop());
-
     window.addEventListener("message", event => this._handleMessage(event), false);
   }
 

--- a/test/rise-embedded-template-test.html
+++ b/test/rise-embedded-template-test.html
@@ -172,60 +172,6 @@
           });
         });
 
-        suite( "legacy play/stop events", () => {
-          test('should send "rise-presentation-play" to template on "rise-playlist-play" event', () => {
-            const element = fixture('StaticValueTestFixture');
-            const iframe = element.shadowRoot.children[0];
-
-            const event = new Event("message");
-            event.data = { topic: "rise-components-ready" };
-            event.source = iframe.contentWindow;
-            element._handleMessage(event);
-
-            sandbox.stub(element, "_sendMessageToTemplate");
-
-            element.dispatchEvent(new Event("rise-playlist-play"));
-
-            assert.equal(element._sendMessageToTemplate.calledWith({ topic: "rise-presentation-play" }), true);
-          });
-
-          test('should send "rise-presentation-stop" to template on "rise-playlist-stop" event', () => {
-            const element = fixture('StaticValueTestFixture');
-            const iframe = element.shadowRoot.children[0];
-
-            const event = new Event("message");
-            event.data = { topic: "rise-components-ready" };
-            event.source = iframe.contentWindow;
-            element._handleMessage(event);
-
-            sandbox.stub(element, "_sendMessageToTemplate");
-
-            element.dispatchEvent(new Event("rise-playlist-stop"));
-
-            assert.equal(element._sendMessageToTemplate.calledWith({ topic: "rise-presentation-stop" }), true);
-          });
-
-          test('should not "rise-presentation-play" to template on "rise-playlist-play" event if template is not ready', () => {
-            const element = fixture('StaticValueTestFixture');
-
-            sandbox.stub(element, "_sendMessageToTemplate");
-
-            element.dispatchEvent(new Event("rise-playlist-play"));
-
-            assert.equal(element._sendMessageToTemplate.calledWith({ topic: "rise-presentation-play" }), false);
-          });
-
-          test('should not "rise-presentation-stop" to template on "rise-playlist-stop" event if template is not ready', () => {
-            const element = fixture('StaticValueTestFixture');
-
-            sandbox.stub(element, "_sendMessageToTemplate");
-
-            element.dispatchEvent(new Event("rise-playlist-stop"));
-
-            assert.equal(element._sendMessageToTemplate.calledWith({ topic: "rise-presentation-stop" }), false);
-          });
-        });
-
         test('should send "report-done" event when template is done', () => {
           // stub super class method
           sandbox.stub(RiseElement.prototype, "_sendDoneEvent");


### PR DESCRIPTION
## Description
Remove deprecated event handlers

## Motivation and Context
Playlist component epic.

Events deprecated as per https://github.com/Rise-Vision/rise-playlist-new/pull/38.

## How Has This Been Tested?
Tested changes locally via proxy. Updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No